### PR TITLE
Fix react warnings

### DIFF
--- a/client/js/components/main/assessment.jsx
+++ b/client/js/components/main/assessment.jsx
@@ -94,20 +94,24 @@ export class Assessment extends React.Component{
     if(props.questionCount === undefined || index >= props.questionCount || index < 0){
       return <div></div>;
     }
-    return <Item
-      assessment       = {props.assessment}
-      settings         = {props.settings}
-      question         = {props.allQuestions[index]}
-      currentItemIndex = {index}
-      questionCount    = {props.questionCount}
-      messageIndex     = {props.progress.answerMessageIndex[index]}
-      allQuestions     = {props.allQuestions}
-      studentAnswers   = {{/*this.props.studentAnswers*/}}
-      outcomes         = {props.outcomes}
-      goToNextQuestion = {() => {props.nextQuestion();}}
-      goToPrevQuestion = {() => {props.previousQuestion();}}
-      submitAssessment = {() => {this.submitAssessment();}}
-      />;
+
+    return (
+      <Item
+          key              = {index /* react uses this to distinguish children */}
+          assessment       = {props.assessment}
+          settings         = {props.settings}
+          question         = {props.allQuestions[index]}
+          currentItemIndex = {index}
+          questionCount    = {props.questionCount}
+          messageIndex     = {props.progress.answerMessageIndex[index]}
+          allQuestions     = {props.allQuestions}
+          studentAnswers   = {{/*this.props.studentAnswers*/}}
+          outcomes         = {props.outcomes}
+          goToNextQuestion = {() => {props.nextQuestion();}}
+          goToPrevQuestion = {() => {props.previousQuestion();}}
+          submitAssessment = {() => {this.submitAssessment();}}
+      />
+    );
   }
 
   /**

--- a/client/js/themes/base.js
+++ b/client/js/themes/base.js
@@ -64,7 +64,7 @@ export default {
   btnQuestionBackground: defines.white,
   btnQuestionColor: defines.black,
   btnQuestionTextAlign: "left",
-  btnQuestionPadding: "0",
+  btnQuestionPadding: "0px",
   btnQuestionMarginBottom: "5px",
   btnQuestionDisplay: "block",
   btnQuestionWidth: "100%",


### PR DESCRIPTION
Added a "key" attribute which react uses to keep elements associated to multiple children.  Also, while CSS allows a unitless "0", react doesn't care for it.