### PR TITLE
Fix parse feedback

### DIFF
--- a/client/js/parsers/clix/parser.js
+++ b/client/js/parsers/clix/parser.js
@@ -28,7 +28,7 @@ export function parseFeedback(feedbackXml){
     var $xml = $(xml);
     var feedback = $xml.find('modalFeedback');
     return feedback.html();
-  } else if(feedbackXML === "No feedback available."){
+  } else if(feedbackXml === "No feedback available."){
     // Don't return any feedback when no feedback is available
   } else {
     console.error("We cannot recognize feedback from server");

--- a/client/js/parsers/clix/parser.js
+++ b/client/js/parsers/clix/parser.js
@@ -23,12 +23,15 @@ export default class Parser {
 };
 
 export function parseFeedback(feedbackXml){
-  try{
+  if(feedbackXml.startsWith('<?xml')){
     var xml = $.parseXML(feedbackXml);
     var $xml = $(xml);
     var feedback = $xml.find('modalFeedback');
     return feedback.html();
-  } catch(e) {
-    // If we can't parse the feedback, then return undefined
+  } else if(feedbackXML === "No feedback available."){
+    // Don't return any feedback when no feedback is available
+  } else {
+    console.error("We cannot recognize feedback from server");
   }
+
 }

--- a/client/js/parsers/clix/parser.js
+++ b/client/js/parsers/clix/parser.js
@@ -23,8 +23,12 @@ export default class Parser {
 };
 
 export function parseFeedback(feedbackXml){
-  var xml = $.parseXML(feedbackXml);
-  var $xml = $(xml);
-  var feedback = $xml.find('modalFeedback');
-  return feedback.html();
+  try{
+    var xml = $.parseXML(feedbackXml);
+    var $xml = $(xml);
+    var feedback = $xml.find('modalFeedback');
+    return feedback.html();
+  } catch(e) {
+    // If we can't parse the feedback, then return undefined
+  }
 }

--- a/client/js/parsers/clix/parser.spec.js
+++ b/client/js/parsers/clix/parser.spec.js
@@ -30,7 +30,7 @@ describe("CLIx assessment parser", () => {
 
   });
 
-  fdescribe("parse feedback", () => {
+  describe("parse feedback", () => {
     var feedback = "<modalFeedback  identifier='Feedback1591099233' outcomeIdentifier='FEEDBACKMODAL' showHide='show'><p>Listen carefully</p></modalFeedback>";
 
     it('parses feedback content', () => {

--- a/client/js/parsers/clix/parser.spec.js
+++ b/client/js/parsers/clix/parser.spec.js
@@ -31,16 +31,15 @@ describe("CLIx assessment parser", () => {
   });
 
   describe("parse feedback", () => {
-    var feedback = "<modalFeedback  identifier='Feedback1591099233' outcomeIdentifier='FEEDBACKMODAL' showHide='show'><p>Listen carefully</p></modalFeedback>";
-
+    var feedback = "<?xml version='1.0' encoding='utf-8'?><modalFeedback identifier='assessment.Answer%3A577eab12b3fcec48316ad493%40ODL.MIT.EDU' outcomeIdentifier='FEEDBACKMODAL' showHide='show'><p>Well done!</p></modalFeedback>";
     it('parses feedback content', () => {
       var result = parseFeedback(feedback);
 
-      expect(result).toEqual("<p>Listen carefully</p>");
+      expect(result).toEqual("<p>Well done!</p>");
     });
 
-    it('handles no feedback', () => {
-      var result = parseFeedback(undefined);
+    it('handles no feedback available', () => {
+      var result = parseFeedback("No feedback available.");
 
       expect(result).toEqual(undefined);
     });

--- a/client/js/parsers/clix/parser.spec.js
+++ b/client/js/parsers/clix/parser.spec.js
@@ -30,7 +30,7 @@ describe("CLIx assessment parser", () => {
 
   });
 
-  describe("parse feedback", () => {
+  fdescribe("parse feedback", () => {
     var feedback = "<modalFeedback  identifier='Feedback1591099233' outcomeIdentifier='FEEDBACKMODAL' showHide='show'><p>Listen carefully</p></modalFeedback>";
 
     it('parses feedback content', () => {
@@ -41,6 +41,12 @@ describe("CLIx assessment parser", () => {
 
     it('handles no feedback', () => {
       var result = parseFeedback(undefined);
+
+      expect(result).toEqual(undefined);
+    });
+
+    it('handles bad xml', () => {
+      var result = parseFeedback('<notxml>reallyNotXml');
 
       expect(result).toEqual(undefined);
     });


### PR DESCRIPTION
When Qbank api is called to grade an answer with no answer provided it will return ```feedback: "no feedback available"``` 

parseFeedback now handles this situation by only returning feedback when it can successfully parse the feedback xml. 