### PR TITLE
Remove answer feedback

### DIFF
--- a/client/js/components/assessments/universal_input.jsx
+++ b/client/js/components/assessments/universal_input.jsx
@@ -52,26 +52,6 @@ export default class UniversalInput extends React.Component{
     }
   }
 
-  getGradeState(id, questionResult){
-    if(!questionResult){return UNGRADED;}
-
-    if(_.includes(questionResult.answerIds, id) && questionResult.correct){
-      return CORRECT;
-    } else if(_.includes(questionResult.answerIds, id) && !questionResult.correct) {
-      return INCORRECT;
-    }
-
-    return UNGRADED;
-  }
-
-  getFeedback(id, questionResult){
-    if(!questionResult){return;}
-
-    if(_.includes(questionResult.answerIds, id)){
-      return questionResult.feedback;
-    }
-  }
-
   render(){
     var props = this.props;
     var item = props.item;
@@ -86,8 +66,6 @@ export default class UniversalInput extends React.Component{
         const multipleChoiceAnswer = (answer) => {
           var selectRadio = _.curryRight(props.selectAnswer);
           var id = item.id + "_" + answer.id;
-          var gradeState = this.getGradeState(answer.id, props.questionResult);
-          var feedback = this.getFeedback(answer.id, props.questionResult);
 
           return (
             <RadioButton
@@ -98,8 +76,6 @@ export default class UniversalInput extends React.Component{
                 isHtml={item.isHtml}
                 name="answer-radio"
                 checked={this.wasSelected(answer.id)}
-                gradeState={gradeState}
-                feedback={feedback}
                 selectAnswer={selectRadio(true)}/>
           );
         };
@@ -144,8 +120,6 @@ export default class UniversalInput extends React.Component{
         const multipleAnswer = (answer) => {
           var selectCheckbox = _.curryRight(props.selectAnswer);
           var id = item.id + "_" + answer.id;
-          var gradeState = this.getGradeState(answer.id, props.questionResult);
-          var feedback = this.getFeedback(answer.id, props.questionResult);
 
           return (
             <CheckBox
@@ -155,8 +129,6 @@ export default class UniversalInput extends React.Component{
                 item={answer}
                 isHtml={item.isHtml}
                 checked={this.wasSelected(answer.id)}
-                gradeState={gradeState}
-                feedback={feedback}
                 selectAnswer={selectCheckbox(false)} />
           );
         };

--- a/client/js/components/assessments/universal_input.jsx
+++ b/client/js/components/assessments/universal_input.jsx
@@ -37,11 +37,7 @@ export default class UniversalInput extends React.Component{
     response: React.PropTypes.array,
 
     // User facing strings of the language specified by the 'locale' setting
-    localizedStrings: React.PropTypes.object.isRequired,
-
-    // Graded user response object containing keys
-    // correct:true/false, feedback:"Answer feedback"
-    questionResult: React.PropTypes.object
+    localizedStrings: React.PropTypes.object.isRequired
   }
 
   wasSelected(id){

--- a/client/js/components/common/checkbox.jsx
+++ b/client/js/components/common/checkbox.jsx
@@ -2,9 +2,6 @@
 
 import React from "react";
 
-import { CORRECT, INCORRECT, UNGRADED } from "../assessments/universal_input";
-import FeedbackIcon from "./feedback_icon";
-
 export default class CheckBox extends React.Component{
 
   static propTypes = {
@@ -19,10 +16,6 @@ export default class CheckBox extends React.Component{
 
     selectAnswer: React.PropTypes.func.isRequired,
 
-    // Whether answer is correct, incorrect, or has not been graded.
-    // Should be one of CORRECT, INCORRECT, UNGRADED.
-    gradeState: React.PropTypes.string.isRequired,
-
     // Whether or not input should be disabled
     isDisabled: React.PropTypes.bool,
 
@@ -32,17 +25,6 @@ export default class CheckBox extends React.Component{
 
   selectAnswer(){
     this.props.selectAnswer(this.props.item.id);
-  }
-
-  getFeedback(){
-    if(this.props.feedback){
-      return (
-        <div className="c-answer-feedback">
-            <div
-              dangerouslySetInnerHTML={{__html:this.props.feedback}}/>
-        </div>
-      );
-    }
   }
 
   renderMaterial(material, isHtml) {
@@ -61,13 +43,11 @@ export default class CheckBox extends React.Component{
   render() {
     const props = this.props;
     var containerStyle = "";
-    var feedback = this.getFeedback();
 
     if(this.props.checked === true){containerStyle = "is-clicked";}
 
     return (
       <li className={`c-answer-container ${containerStyle}`}>
-        <FeedbackIcon gradeState={props.gradeState} />
         <label
           htmlFor={props.id}>
           <div className="c-answer-container__radio">
@@ -87,7 +67,6 @@ export default class CheckBox extends React.Component{
             {this.renderMaterial(props.item.material, props.isHtml)}
           </div>
         </label>
-        {feedback}
       </li>
     );
   }

--- a/client/js/components/common/radio_button.jsx
+++ b/client/js/components/common/radio_button.jsx
@@ -2,9 +2,6 @@
 
 import React                             from "react";
 
-import { CORRECT, INCORRECT, UNGRADED }  from "../assessments/universal_input";
-import * as AssessmentActions            from "../../actions/assessment";
-
 export default class RadioButton extends React.Component{
 
   static propTypes = {

--- a/client/js/components/common/radio_button.jsx
+++ b/client/js/components/common/radio_button.jsx
@@ -61,7 +61,6 @@ export default class RadioButton extends React.Component{
   render() {
     const props = this.props;
     var containerStyle = "";
-    var feedback = this.getFeedback();
 
     if(this.props.checked === true){containerStyle = "is-clicked";}
 

--- a/client/js/components/common/radio_button.jsx
+++ b/client/js/components/common/radio_button.jsx
@@ -1,11 +1,9 @@
 "use strict";
 
-import React                  from "react";
+import React                             from "react";
 
-import { CORRECT, INCORRECT, UNGRADED } from "../assessments/universal_input";
-import * as AssessmentActions from "../../actions/assessment";
-import FeedbackIcon from "./feedback_icon";
-
+import { CORRECT, INCORRECT, UNGRADED }  from "../assessments/universal_input";
+import * as AssessmentActions            from "../../actions/assessment";
 
 export default class RadioButton extends React.Component{
 
@@ -20,10 +18,6 @@ export default class RadioButton extends React.Component{
     isHtml: React.PropTypes.bool,
 
     selectAnswer: React.PropTypes.func.isRequired,
-
-    // Whether answer is correct, incorrect, or has not been graded.
-    // Should be one of CORRECT, INCORRECT, UNGRADED.
-    gradeState: React.PropTypes.string.isRequired,
 
     // Whether or not input should be disabled
     isDisabled: React.PropTypes.bool,
@@ -51,17 +45,6 @@ export default class RadioButton extends React.Component{
     return checked;
   }
 
-  getFeedback(){
-    if(this.props.feedback){
-      return (
-        <div className="c-answer-feedback">
-          <div
-            dangerouslySetInnerHTML={{__html:this.props.feedback}}/>
-        </div>
-      );
-    }
-  }
-
   renderMaterial(material, isHtml) {
     if(isHtml) {
       return <div className="c-answer-container__content"
@@ -84,7 +67,6 @@ export default class RadioButton extends React.Component{
 
     return (
       <li className={`c-answer-container ${containerStyle}`}>
-        <FeedbackIcon gradeState={props.gradeState} />
         <label
           htmlFor={props.id}>
           <div className="c-answer-container__radio">
@@ -104,7 +86,6 @@ export default class RadioButton extends React.Component{
             {this.renderMaterial(props.item.material, props.isHtml)}
           </div>
         </label>
-        {feedback}
       </li>
     );
   }


### PR DESCRIPTION
# Code-review checklist #

  * Documentation
      * [x] Interfaces describe how other programmers would use them.
      * [x] Code that is not obvious has documentation describing why
        that code is the way it is.

Removes feedback being rendered on individual answers in favor of rendering feedback only once at the 'item' level. 