### PR TITLE
file upload question check answer button should display save file

### DIFF
--- a/client/js/parsers/clix/selectors.js
+++ b/client/js/parsers/clix/selectors.js
@@ -51,6 +51,7 @@ export function checkButtonText(state, props) {
     case "short_answer_question":
       return localizedStrings.saveAnswerButton;
 
+    case "file_upload_question":
     case "audio_upload_question":
     case "movable_words_sandbox":
       return localizedStrings.saveFileButton;


### PR DESCRIPTION
# Code-review checklist #

  * Documentation
      * [ ] Interfaces describe how other programmers would use them.
      * [ ] Code that is not obvious has documentation describing why
        that code is the way it is.

* Generic file upload should display 'Save File' text instead of 'Check Answer'